### PR TITLE
Fix PrimaryActionButtonStyle to avoid invalid BasedOn markup

### DIFF
--- a/FishApp/FishApp/Resources/Styles/Styles.xaml
+++ b/FishApp/FishApp/Resources/Styles/Styles.xaml
@@ -460,7 +460,7 @@
         <Setter Property="LineHeight" Value="1.2" />
     </Style>
 
-    <Style TargetType="Button" x:Key="PrimaryActionButtonStyle" BasedOn="{StaticResource {x:Type Button}}">
+    <Style TargetType="Button" x:Key="PrimaryActionButtonStyle">
         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
         <Setter Property="FontAttributes" Value="Bold" />
     </Style>


### PR DESCRIPTION
## Summary
- remove the invalid `{x:Type Button}` StaticResource usage in `PrimaryActionButtonStyle` so the style parses without a Key property error

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb011096c8331a95d7235b0d68db7